### PR TITLE
Added support for Windows

### DIFF
--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -5,6 +5,6 @@
     "protractor": "<%=ptorVersion%>"
   },
   "scripts": {
-    "install": "./node_modules/protractor/bin/webdriver-manager update"
+    "install": "node ./node_modules/protractor/bin/webdriver-manager update"
   }
 }


### PR DESCRIPTION
In Window environments the command line doesn't know how to execute the javascript file.
By prefixing it with node, the issue is resolved
